### PR TITLE
Remove UNIQUE props in code column on codes table

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -100,7 +100,7 @@ async function checkCodeForEventUsername(db, event_id, username) {
         [event_id, username]
       );
       const code = await t.one(
-        "UPDATE codes SET username = $1, claimed_date = $3::timestamp WHERE code in (SELECT code FROM codes WHERE event_id = $2 AND username IS NULL ORDER BY RANDOM() LIMIT 1) RETURNING code",
+        "UPDATE codes SET username = $1, claimed_date = $3::timestamp WHERE event_id = $2 AND code in (SELECT code FROM codes WHERE event_id = $2 AND username IS NULL ORDER BY RANDOM() LIMIT 1) RETURNING code",
         [username, event_id, now]
       );
       console.log(`[DB] checking event: ${event_id}, user: ${username} `);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,4 +1,4 @@
 CREATE TABLE events ( id text PRIMARY KEY, server VARCHAR ( 50 ) NOT NULL, channel TEXT, start_date timestamp , end_date timestamp, response_message TEXT, pass TEXT UNIQUE, created_by TEXT, created_date timestamp, file_url TEXT, is_active BOOLEAN DEFAULT TRUE, is_whitelisted BOOLEAN NULL, whitelist_file_url TEXT NULL);
-CREATE TABLE codes ( ID SERIAL PRIMARY KEY, code VARCHAR ( 50 ) UNIQUE NOT NULL, event_id TEXT, username TEXT NULL, is_active BOOLEAN DEFAULT TRUE, claimed_date timestamp NULL, created_date timestamp);
+CREATE TABLE codes ( ID SERIAL PRIMARY KEY, code VARCHAR ( 50 ) NOT NULL, event_id TEXT, username TEXT NULL, is_active BOOLEAN DEFAULT TRUE, claimed_date timestamp NULL, created_date timestamp);
 CREATE TABLE banned ( ID SERIAL PRIMARY KEY, user_id TEXT );
 -- TODO: contraint between events and codes


### PR DESCRIPTION
This aims to resolve the problem where you weren't able to insert the same code url in the table, either for different events. Maybe this is not the best behavior, but mitigate since we still don't have a client validation. 

Also, resolves this issue: https://github.com/glamperd/POAPBot/issues/4